### PR TITLE
最近はcatkin_toolsを使うのが良いと聞きましたがどうしましょうか

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ wstool set jsk_recognition https://github.com/jsk-ros-pkg/jsk_recognition --gi
 $ wstool update
 $ cd ..
 $ rosdep install -y -r --from-paths .
-$ catkin_make
+$ catkin build
 $ source devel/setup.bash
 ```
 


### PR DESCRIPTION
catkin_toolsはsudo apt-get install python-catkin-toolsではいります。
http://ros-users.122217.n3.nabble.com/Some-ROS-devs-got-frustrated-with-Catkin-You-won-t-believe-what-happened-next-tt4021703.html