### PR TITLE
Add script to visualize sift keypoints

### DIFF
--- a/jsk_2014_picking_challenge/launch/visualize_sift.launch
+++ b/jsk_2014_picking_challenge/launch/visualize_sift.launch
@@ -1,0 +1,22 @@
+<launch>
+  <arg name="test" default="false" />
+  <arg name="input_image" default="/image_publish_server/output" if="$(arg test)" />
+  <arg name="input_info" default="/fake_camera_info_publisher/output" if="$(arg test)" />
+  <arg name="input_image" default="/kinect2/rgb/image" unless="$(arg test)" />
+  <arg name="input_info" default="/kinect2/rgb/camera_info" unless="$(arg test)" />
+
+  <group if="$(arg test)">
+    <!-- test -->
+    <node pkg="jsk_2014_picking_challenge" type="image_publish_server.py" name="image_publish_server"></node>
+    <node pkg="jsk_2014_picking_challenge" type="fake_camera_info_publisher.py" name="fake_camera_info_publisher"></node>
+  </group>
+
+  <node pkg="imagesift" type="imagesift" name="imagesift">
+    <remap from="/image" to="$(arg input_image)" />
+    <remap from="/camera_info" to="$(arg input_info)" />
+  </node>
+  <node pkg="jsk_2014_picking_challenge" type="visualize_sift.py" name="visualize_sift">
+    <remap from="~input/image" to="$(arg input_image)" />
+    <remap from="~input/feature" to="/ImageFeature0D" />
+  </node>
+</launch>

--- a/jsk_2014_picking_challenge/scripts/visualize_sift.py
+++ b/jsk_2014_picking_challenge/scripts/visualize_sift.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+from math import pi
+
+import cv2
+
+import rospy
+import cv_bridge
+from sensor_msgs.msg import Image
+from posedetection_msgs.msg import ImageFeature0D
+
+
+class VisualizeSift(object):
+    def __init__(self):
+        self.features = None
+        self.imgray = None
+        rospy.Subscriber('~input/image', Image, self._cb_img)
+        rospy.Subscriber('~input/feature', ImageFeature0D, self._cb_features)
+        self.pub = rospy.Publisher('~output', Image, queue_size=1)
+
+    def _cb_features(self, msg):
+        self.features = msg.features
+
+    def _cb_img(self, imgmsg):
+        bridge = cv_bridge.CvBridge()
+        self.imgray = bridge.imgmsg_to_cv2(imgmsg, desired_encoding='mono8')
+
+    def spin_once(self):
+        if self.features is None:
+            return
+        features = self.features
+        imgray = self.imgray
+        bridge = cv_bridge.CvBridge()
+        keypoints = []
+        for i in xrange(len(features.positions)/2):
+            x = features.positions[2*i]
+            y = features.positions[2*i+1]
+            size = features.scales[i]
+            ori = features.orientations[i] / pi * 180
+            kp = cv2.KeyPoint(x=x, y=y, _size=size, _angle=ori)
+            keypoints.append(kp)
+        out = cv2.drawKeypoints(imgray, keypoints,
+                flags=cv2.DRAW_MATCHES_FLAGS_DRAW_RICH_KEYPOINTS)
+        imgmsg = bridge.cv2_to_imgmsg(out, encoding='bgr8')
+        self.pub.publish(imgmsg)
+
+    def spin(self):
+        rate = rospy.Rate(rospy.get_param('rate', 1))
+        while not rospy.is_shutdown():
+            self.spin_once()
+            rate.sleep()
+
+
+if __name__ == '__main__':
+    rospy.init_node('visualize_sift')
+    vis = VisualizeSift()
+    vis.spin()
+


### PR DESCRIPTION
You can visualize sift keypoints using scripts/visualize_sift.py.
This script is for **test** and **debug**.
Usage
-----
```sh
$ roslauch jsk_2014_picking_challenge visualize_sift.launch test:=true
$ rosservice call /image_publish_server `rospack find jsk_2014_picking_challenge`/data/paste.png
$ rosrun image_view image_view image:=/visualize_sift/output
```