### PR TITLE
add Simulator Mode

### DIFF
--- a/jsk_2014_picking_challenge/euslisp/motion/pick-object.l
+++ b/jsk_2014_picking_challenge/euslisp/motion/pick-object.l
@@ -67,5 +67,8 @@
 
       (send *ri* :angle-vector-sequence revavs :fast :default-controller 0 :scale 5)
       (send *ri* :wait-interpolation)
+      (if *simulator-p*
+	  (return)
+	)
       (ros::spin-once) ;; check if grabbed
       )))

--- a/jsk_2014_picking_challenge/euslisp/robot-init.l
+++ b/jsk_2014_picking_challenge/euslisp/robot-init.l
@@ -2,6 +2,7 @@
 (load "package://jsk_2014_picking_challenge/euslisp/model/pod-lowres.l")
 (load "package://jsk_2014_picking_challenge/euslisp/model/order-bin.l")
 
+(setq *simulator-p* nil)
 (defun apc-init ()
   (baxter-init)
   (send *baxter* :locate #f(0 0 950) :world)
@@ -9,4 +10,5 @@
   (pod-init)
   (orderbin-init)
   (objects (list *baxter* *pod* *orderbin*))
+  (setq *simulator-p* (not (send *ri* :joint-action-enable)))
   t)

--- a/jsk_2014_picking_challenge/euslisp/robot-main.l
+++ b/jsk_2014_picking_challenge/euslisp/robot-main.l
@@ -23,6 +23,7 @@
       ; get status from parameter server
       (setq arm (str-to-arm (elt work 0)) target (str-to-symbol (elt work 1)))
       (setq state (ros::get-param (format nil "~A_limb/state" (arm-to-str arm))))
+      (send *irtviewer* :draw-objects)
       (ros::ros-info "state: ~A, arm: ~A, target: ~A" state (arm-to-str arm) (symbol-to-str target))
       (cond
         ((string= state "move_to_target_bin")
@@ -51,5 +52,7 @@
 ; TODO: make workorder publisher
 (setq workorder (list '("right" :c) '("left" :a) '("right" :b) '("left" :d) '("right" :e)))
 
-(apc-init)
-(main)
+(warn "~% Commands ~%")
+(warn "(apc-init) : Setup~%")
+(warn "(main)     : Start the loop~%")
+

--- a/jsk_2014_picking_challenge/launch/challenge.launch
+++ b/jsk_2014_picking_challenge/launch/challenge.launch
@@ -5,6 +5,7 @@
   <arg name="bof" default="true"/>
   <arg name="sift" default="false"/>
   <arg name="color" default="false"/>
+  <arg name="launch_main" default="false"/>
   <env name="DISPLAY" value="" unless="$(arg DEBUG)" />
 
   <include file="$(find jsk_2014_picking_challenge)/launch/upload_baxter.launch">
@@ -23,11 +24,9 @@
     args="--file $(find jsk_2014_picking_challenge)/data/example.json">
   </node>
 
-  <!-- motion -->
-  <node pkg="jsk_2014_picking_challenge" type="move-arm2target-bin-server.l" name="move_arm2target_bin" output="screen"></node>
-  <node pkg="jsk_2014_picking_challenge" type="object-picking-server.l" name="object_picking" output="screen"></node>
-  <node pkg="jsk_2014_picking_challenge" type="move-for-verification.l" name="move_for_verification" output="screen"></node>
-  <node pkg="jsk_2014_picking_challenge" type="put-orderbin.l" name="put_orderbin" output="screen"></node>
+  <!-- main -->
+  <node if="launch_main" pkg="jsk_2014_picking_challenge" type="robot-main.l" name="challenge_main"
+	args="&quot;(progn (apc-init) (main))&quot;"/>
 
   <!-- recognition -->
   <include file="$(find jsk_2014_picking_challenge)/launch/passthrough_image.launch">


### PR DESCRIPTION
@wkentaro I changed someparts.
- We need to type `(apc-init)` and `(main)` . If you want to execute without typing every time, please type as below
```
roseus robot-main.l "(progn (apc-init)(main))"
```
and If you want to execute in launch, automatically, please write like as below link

https://github.com/jsk-ros-pkg/jsk_demos/blob/master/jsk_2013_04_pr2_610/launch/demo_common.launch#L17

- I added simulater mode , below parts check the `*ri*` is simulator mode or not. You can access with `*simulator-p*` as global variables.
  - With this, in pick-objects, skipping the grap check loop.
```
(setq *simulator-p* (not (send *ri* :joint-action-enable)))
```