### PR TITLE
[euslisp/motion/check-if-grabbed.l] remove ros-info in callback func

### DIFF
--- a/jsk_2014_picking_challenge/euslisp/motion/check-if-grabbed.l
+++ b/jsk_2014_picking_challenge/euslisp/motion/check-if-grabbed.l
@@ -8,16 +8,10 @@
 (defparameter *grabbed-left* nil)
 (defparameter *grabbed-right* nil)
 
-(defun grabbed-left-cb (msg)
-  (ros::ros-info (format nil "~A" (send msg :data)))
-  (setq *grabbed-left* (send msg :data)))
-
-(defun grabbed-right-cb (msg)
-  (ros::ros-info (format nil "~A" (send msg :data)))
-  (setq *grabbed-right* (send msg :data)))
-
-(ros::subscribe "gripper_grabbed/limb/left/state" std_msgs::Bool #'grabbed-left-cb)
-(ros::subscribe "gripper_grabbed/limb/right/state" std_msgs::Bool #'grabbed-right-cb)
+(ros::subscribe "gripper_grabbed/limb/left/state" std_msgs::Bool
+                #'(lambda (msg) (setq *grabbed-left* (send msg :data))))
+(ros::subscribe "gripper_grabbed/limb/right/state" std_msgs::Bool
+                #'(lambda (msg) (setq *grabbed-right* (send msg :data))))
 
 (defun check-if-grabbed (arm)
   (let (state)


### PR DESCRIPTION
Relative issue: https://github.com/start-jsk/2014-semi/issues/370