### PR TITLE
[utils.l] Add underscore-to-space for speaking

### DIFF
--- a/jsk_2014_picking_challenge/euslisp/robot-main.l
+++ b/jsk_2014_picking_challenge/euslisp/robot-main.l
@@ -54,7 +54,7 @@
         ((string= state "pick_object")
          (incf n-tried)
          (ros::ros-info "Move to Bin ~A. Target is ~A." (key-to-str target) target-object)
-         (speak-en (format nil "Move to Bin ~A. Target is ~A." (key-to-str target) target-object) :google t)
+         (speak-en (format nil "Move to Bin ~A. Target is ~A." (key-to-str target) (underscore-to-space target-object)) :google t)
          (move-to-target-bin arm target)
          (speak-en (format nil "Pick Object in ~A." (key-to-str target)) :google t)
          (pick-object arm target)

--- a/jsk_2014_picking_challenge/euslisp/utils.l
+++ b/jsk_2014_picking_challenge/euslisp/utils.l
@@ -28,3 +28,10 @@
     (ros::advertise name data-class queue-size)
     (unix::sleep 1)))
 
+(defun underscore-to-space (str_)
+  (let* ((str (copy-list str_)))
+    (while
+      (position #\_ str)
+      (setf (schar str (position #\_ str)) #\ ))
+    str)
+


### PR DESCRIPTION
**Usage**
```
> (underscore-to-space "oreo_mega_stuf")
"oreo mega stuf"
```