### PR TITLE
modified pick-object to avoid return objects's collision

### DIFF
--- a/jsk_2014_picking_challenge/euslisp/motion/pick-object.l
+++ b/jsk_2014_picking_challenge/euslisp/motion/pick-object.l
@@ -64,6 +64,7 @@
                                  ))
                               grasp-depth-z)))
 
+    ;; (format t "depth ~A ~A~%" depth depth-threshold)
     (if (and (> depth depth-threshold)
              (or (eq bin :a) (eq bin :b) (eq bin :c)))
         (setq grasp-side-z 70))
@@ -387,18 +388,28 @@
       )
     result-patterns))
 
-(defun pick-object (arm bin &key (to-see-if-grabbed nil))
+(defun delete-arbitrary-patterns (patterns arbitrary-patterns)
+  (let ((result-patterns patterns))
+    (dolist (a-pat arbitrary-patterns)
+      (setq result-patterns (remove-if #'(lambda (x) (equal x a-pat)) result-patterns))
+      )
+    result-patterns))
+
+(defun pick-object (arm bin &key (to-see-if-grabbed nil) (n-tried nil))
   (let* (av avs target-labels
+            (short-range 30)
+            (middle-range 80)
+            (long-range 150)
             (patterns ;; pair of (pattern . depth)
-             '((:middle . 30) (:middle . 80) (:middle . 150)
-                       (:rotate-and-left . 30 ) (:left-most . 30)
-                       (:rotate-and-right . 30) (:right-most . 30) ;;
-                       (:rotate-and-left . 80) (:left-most . 80)
-                       (:rotate-and-right . 80) (:right-most . 80) ;;
-                       (:rotate-and-left . 150) (:left-most . 150)
-                       (:rotate-and-right . 150) (:right-most . 150) ;;
-                       (:left . 80) (:right . 80) (:left . 30) (:right . 30) (:left . 150) (:right . 150)
-                       (:middle-left . 80) (:middle-right . 80) (:middle-left . 30) (:middle-right . 30) (:middle-left . 150) (:middle-right . 150)
+             '((:middle . short-range) (:middle . middle-range) (:middle . long-range)
+                       (:rotate-and-left . short-range ) (:left-most . short-range)
+                       (:rotate-and-right . short-range) (:right-most . short-range) ;;
+                       (:rotate-and-left . middle-range) (:left-most . middle-range)
+                       (:rotate-and-right . middle-range) (:right-most . middle-range) ;;
+                       (:rotate-and-left . long-range) (:left-most . long-range)
+                       (:rotate-and-right . long-range) (:right-most . long-range) ;;
+                       (:left . middle-range) (:right . middle-range) (:left . short-range) (:right . short-range) (:left . long-range) (:right . long-range)
+                       (:middle-left . middle-range) (:middle-right . middle-range) (:middle-left . short-range) (:middle-right . short-range) (:middle-left . long-range) (:middle-right . long-range)
                        ))
             )
     (send *baxter* arm :inverse-kinematics
@@ -411,6 +422,12 @@
     (setq target-labels (detect-object-pos-in-bin arm))
     (setq patterns (append (select-target-pattern-from-labels target-labels) patterns))
     (setq patterns (delete-duplicate-patterns patterns :overlap 2))
+
+    (if n-tried
+        (setq patterns (delete-arbitrary-patterns patterns '((:middle . long-range)))))
+
+    ;; (setq patterns (delete-arbitrary-patterns patterns '((:middle . 30) (:middle . 80) (:middle . 150))))
+    ;; (format t "patterns = ~A~%" patterns)
 
     ;; insert arm to target bin
     (dolist (av (insert-to-pick-object-avs arm bin))
@@ -427,7 +444,7 @@
     (ros::ros-info "try to pick object ~A ~A" arm bin)
     (while
         (and patterns
-             (not (try-to-pick-object arm bin (caar patterns) (cdar patterns):call-see-if-grabbed-function to-see-if-grabbed)))
+             (not (try-to-pick-object arm bin (caar patterns) (eval (cdar patterns)) :call-see-if-grabbed-function to-see-if-grabbed)))
       (pop patterns)
       (unless *simulator-p* (speak-en  "Fail to catch the target" :google t)))
     ;; take arm out of bin

--- a/jsk_2014_picking_challenge/euslisp/motion/pick-object.l
+++ b/jsk_2014_picking_challenge/euslisp/motion/pick-object.l
@@ -35,20 +35,21 @@
                                (check-depth-z  10) ;; move z up to check grabbed
                                (grasp-side-z   80) ;; move z down to side grasp
                                (grasp-side-z-down   50) ;; move z down to side (grasp after rotate)
-			       (grasp-z-offset 30) ;; z for returning to original pose
+                               (grasp-z-offset 30) ;; z for returning to original pose
                                (debug-mode nil)
                                )
   (let* ((grasp-left-most-dist 60)
-        (grasp-right-most-dist -60)
-        (grasp-left-dist 50)
-        (grasp-right-dist -50)
-        (grasp-middle-left-dist 20)
-        (grasp-middle-right-dist -20)
-        (grasp-limit-left-side 50)
-        (grasp-limit-right-side -50)
-        (grasp-half-limit-left-side (/ grasp-limit-left-side 2))
-        (grasp-half-limit-right-side (/ grasp-limit-right-side 2))
-        )
+         (grasp-right-most-dist -60)
+         (grasp-left-dist 50)
+         (grasp-right-dist -50)
+         (grasp-middle-left-dist 20)
+         (grasp-middle-right-dist -20)
+         (grasp-limit-left-side 50)
+         (grasp-limit-right-side -50)
+         (grasp-half-limit-left-side (/ grasp-limit-left-side 2))
+         (grasp-half-limit-right-side (/ grasp-limit-right-side 2))
+         (depth-threshold 90)
+         )
     ;; load robot-test.l and run following command to get this information
     ;; (check-pick-offset :rarm '(:c :f :i :l) '((:middle . 30)))
     ;; (check-pick-offset :larm '(:a :d :g :j :b :e :h :k) '((:middle . 30)))
@@ -62,6 +63,10 @@
                                  (case bin (:c 90) (:f 80) (:i 115) (:l 130))
                                  ))
                               grasp-depth-z)))
+
+    (if (and (> depth depth-threshold)
+             (or (eq bin :a) (eq bin :b) (eq bin :c)))
+        (setq grasp-side-z 70))
 
     (move-end-pos-with-interpolation arm :x depth :time 1000)
 
@@ -175,15 +180,15 @@
       (send *ri* :wait-interpolation)
 
       (if
-        (and
-          (not *simulator-p*)
-          call-see-if-grabbed-function
-          (see-if-grabbed arm)
-          )
-        (progn
-          (ros::ros-info "finish because see if grabbed")
-          (return-from try-to-pick-object t)
-          )
+          (and
+           (not *simulator-p*)
+           call-see-if-grabbed-function
+           (see-if-grabbed arm)
+           )
+          (progn
+            (ros::ros-info "finish because see if grabbed")
+            (return-from try-to-pick-object t)
+            )
         (return-from try-to-pick-object nil)))
     ;; patterns after grabbed
     (ros::ros-info "take arm from target bin")
@@ -227,8 +232,8 @@
        (send *ri* :wait-interpolation)
        (move-end-pos-with-interpolation arm :z grasp-z-offset :time 1000)
        (move-end-pos-with-interpolation arm
-					:y (- grasp-half-limit-left-side grasp-limit-left-side) 
-					:time 1000
+                                        :y (- grasp-half-limit-left-side grasp-limit-left-side)
+                                        :time 1000
                                         :force t)
        )
       (:rotate-and-right
@@ -236,9 +241,9 @@
        (send *ri* :angle-vector (send *baxter* :angle-vector) 1000)
        (send *ri* :wait-interpolation)
        (move-end-pos-with-interpolation arm :z grasp-z-offset :time 1000)
-       (move-end-pos-with-interpolation arm 
-					:y (- grasp-half-limit-left-side grasp-limit-right-side)
-					:time 1000
+       (move-end-pos-with-interpolation arm
+                                        :y (- grasp-half-limit-left-side grasp-limit-right-side)
+                                        :time 1000
                                         :force t)
        )
       )
@@ -250,33 +255,170 @@
       )
     t))
 
-(defun pick-object (arm bin &key (to-see-if-grabbed nil))
-  (let* (av avs
-            (patterns
-             '(:middle :middle :middle
-                       :rotate-and-left :left-most
-		       :rotate-and-right :right-most
-                       :rotate-and-left :left-most
-		       :rotate-and-right :right-most
-                       :rotate-and-left :left-most
-		       :rotate-and-right :right-most
-                       :left :right :left :right :left :right
-                       :middle-left :middle-right :middle-left :middle-right :middle-left :middle-right
-                       ))
-            (depths '(30 80 150
-                         30 30 30 30
-			 80 80 80 80
-			 150 150 150 150
-                         80 80 30 30 150 150
-                         80 80 30 30 150 150
-                         ))
+(defun select-target-pattern-from-labels (target-labels)
+  (let ((len (length target-labels))
+        patterns
+        (short-range 30)
+        (middle-range 80)
+        (long-range 150)
+        )
+    (labels ((neighbor (index)
+                       (let ((cnt 0)))
+                       (dolist (c '(1 -1 6 -6))
+                         (if (and (<= 0 (+ c index)) (< c 19)
+                                  (and (= c 1) (not (or (= index 6) (= index 12) (= index 18))))
+                                  (and (= c -1) (not (or (= index 1) (= index 7) (= index 13))))
+                                  (find (* 1.0 (+ c index)) target-labels)
+                                  )
+                             (setq cnt (1+ cnt))
+                         )
+                         )))
+      (dotimes (i len)
+        (let* ((label (elt target-labels i))
+              (c))
+          (setq c (neighbor label))
+          (case label
+            (1.0
+             (case c
+               (0 (pushback (cons :left-most long-range) patterns))
+               ((1 2 3) (pushback (cons :rotate-and-left middle-range) patterns)
+                (pushback (cons :left-most middle-range) patterns)
+                )))
+            (2.0
+             (case c
+               ((1 2 3) (pushback (cons :left long-range) patterns))))
+            (3.0
+             (case c
+               ((1 2 3)
+                (pushback (cons :middle-left long-range) patterns)
+                (pushback (cons :middle middle-range) patterns))))
+            (4.0
+             (case c
+               ((1 2 3)
+                (pushback (cons :middle long-range) patterns)))
+             )
+            (5.0
+             (case c
+               ((1 2 3) (pushback (cons :right long-range) patterns))))
+            (6.0
+             (case c
+               (0 (pushback (cons :right-most long-range) patterns))
+               ((1 2 3)
+                (pushback (cons :rotate-and-right middle-range) patterns)
+                (pushback (cons :right-most middle-range) patterns))))
+            (7.0
+             (pushback (cons :rotate-and-left middle-range) patterns)
+             (pushback (cons :left-most middle-range) patterns)
+             )
+            (8.0
+             (pushback (cons :left middle-rnage) patterns)
+             (pushback (cons :middle-left middle-range) patterns)
+             )
+            (9.0
+             (pushback (cons :middle-left middle-range) patterns)
+             (pushback (cons :middle middle-range) patterns)
+             )
+            (10.0
+             (pushback (cons :middle middle-range) patterns)
+             (pushback (cons :middle-right middle-range) patterns)
+             )
+            (11.0
+             (pushback (cons :right middle-rnage) patterns)
+             (pushback (cons :middle-right middle-range) patterns)
+             )
+            (12.0
+             (pushback (cons :rotate-and-right middle-range) patterns)
+             (pushback (cons :right-most middle-range) patterns)
+             )
+            (13.0
+             (case c
+               ((0 1 2 3)
+                (pushback (cons :rotate-and-left short-range) patterns)
+                (pushback (cons :left-most short-range) patterns))
+               )
+             )
+            (14.0
+             (pushback (cons :left short-range) patterns)
+             (pusbback (cons :left-most short-range) patterns)
+             )
+            (15.0
+             (pushback (cons :middle-left short-range) patterns)
+             (pushback (cons :left short-range) patterns)
+             (pushback (cons :middle short-range) patterns)
+             )
+            (16.0
+             (pushback (cons :middle-right short-range) patterns)
+             (pushback (cons :middle short-range) patterns)
+             (pushback (cons :left short-range) patterns)
+             )
+            (17.0
+             (pushback (cons :left short-range) patterns)
+             (pushback (cons :left-most short-range) patterns)
+             (pushback (cons :middle-left short-range) patterns)
+             )
+            (18.0
+             (case c
+               ((0 1 2 3)
+                (pushback (cons :rotate-and-right short-range) patterns)
+                (pushback (cons :right-most short-range) patterns)))
+             )
             )
+          )
+        )
+      patterns)
+    ))
+
+(defun delete-duplicate-patterns (patterns &key (overlap 1))
+  (let ((pat-map (make-hash-table :test #'equal))
+        result-patterns)
+    (dolist (pat patterns)
+      (cond ((null (gethash pat pat-map))
+             (setf (gethash pat pat-map) 1)
+             (pushback pat result-patterns)
+             )
+            ((< (gethash pat pat-map) overlap)
+             (setf (gethash pat pat-map) (1+ (gethash pat pat-map)))
+             (pushback pat result-patterns)
+             )
+            (t
+             (format t "deleted pattern ~A~%" pat)
+             )
+          )
+      )
+    result-patterns))
+
+(defun pick-object (arm bin &key (to-see-if-grabbed nil))
+  (let* (av avs target-labels
+            (patterns ;; pair of (pattern . depth)
+             '((:middle . 30) (:middle . 80) (:middle . 150)
+                       (:rotate-and-left . 30 ) (:left-most . 30)
+                       (:rotate-and-right . 30) (:right-most . 30) ;;
+                       (:rotate-and-left . 80) (:left-most . 80)
+                       (:rotate-and-right . 80) (:right-most . 80) ;;
+                       (:rotate-and-left . 150) (:left-most . 150)
+                       (:rotate-and-right . 150) (:right-most . 150) ;;
+                       (:left . 80) (:right . 80) (:left . 30) (:right . 30) (:left . 150) (:right . 150)
+                       (:middle-left . 80) (:middle-right . 80) (:middle-left . 30) (:middle-right . 30) (:middle-left . 150) (:middle-right . 150)
+                       ))
+            )
+    (send *baxter* arm :inverse-kinematics
+          (make-cascoords :pos (v+ (send *pod* bin) #f(90 0 0)))
+          :revert-if-fail nil
+          :rotation-axis :z)
+    (send *ri* :angle-vector (send *baxter* :angle-vector) 1000)
+    (send *irtviewer* :draw-objects)
+
+    (setq target-labels (detect-object-pos-in-bin arm))
+    (setq patterns (append (select-target-pattern-from-labels target-labels) patterns))
+    (setq patterns (delete-duplicate-patterns patterns :overlap 2))
 
     ;; insert arm to target bin
     (dolist (av (insert-to-pick-object-avs arm bin))
       (send *irtviewer* :draw-objects)
       (send *ri* :angle-vector av 3000)
       (send *ri* :wait-interpolation))
+
+    ;; detect object from arm's camera
     ;; store image to compare it with one after trying to pick
     (start-image-time-diff arm)
     ;; make vacuum on
@@ -285,7 +427,8 @@
     (ros::ros-info "try to pick object ~A ~A" arm bin)
     (while
         (and patterns
-             (not (try-to-pick-object arm bin (pop patterns) (pop depths) :call-see-if-grabbed-function to-see-if-grabbed)))
+             (not (try-to-pick-object arm bin (caar patterns) (cdar patterns):call-see-if-grabbed-function to-see-if-grabbed)))
+      (pop patterns)
       (unless *simulator-p* (speak-en  "Fail to catch the target" :google t)))
     ;; take arm out of bin
     (ros::ros-info "take arm out of bin ~A ~A" arm bin)

--- a/jsk_2014_picking_challenge/euslisp/robot-main.l
+++ b/jsk_2014_picking_challenge/euslisp/robot-main.l
@@ -82,8 +82,8 @@
                (member target-object (get-objects-to-see-if-grabbed))
                (= (length (get-bin-contents target)) 1)
                )
-           (pick-object arm target :to-see-if-grabbed t)
-           (pick-object arm target :to-see-if-grabbed nil)
+           (pick-object arm target :to-see-if-grabbed t :n-tried n-tried)
+           (pick-object arm target :to-see-if-grabbed nil :n-tried n-tried)
            )
          (incf n-tried)  ;; how many times to try to pick
          (if (= (length (get-bin-contents target)) 1)


### PR DESCRIPTION
modified pick-object to avoid return objects's collision
add pick-objects's argument :n-tried